### PR TITLE
Hash and upload

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
-# gazelle:prefix github.com/buildbarn/bb-storage
+# gazelle:prefix github.com/sdclarke/blake-client
 # gazelle:resolve proto build/bazel/remote/execution/v2/remote_execution.proto @com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:remote_execution_proto
 # gazelle:resolve proto go build/bazel/remote/execution/v2/remote_execution.proto @com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library
 gazelle(

--- a/cmd/blake3zcc_hasher/BUILD.bazel
+++ b/cmd/blake3zcc_hasher/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/blobuploader:go_default_library",
-        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/digest:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/cmd/blake3zcc_hasher/BUILD.bazel
+++ b/cmd/blake3zcc_hasher/BUILD.bazel
@@ -3,9 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "github.com/buildbarn/bb-storage/cmd/blake3zcc_hasher",
+    importpath = "github.com/sdclarke/blake-client/cmd/blake3zcc_hasher",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/blobuploader:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/digest:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/cmd/blake3zcc_hasher/main.go
+++ b/cmd/blake3zcc_hasher/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"log"
 
-	//remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/sdclarke/blake-client/pkg/blobuploader"
 	"google.golang.org/grpc"

--- a/cmd/blake3zcc_hasher/main.go
+++ b/cmd/blake3zcc_hasher/main.go
@@ -3,16 +3,12 @@ package main
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"flag"
-	"fmt"
-	"io"
 	"log"
-	"os"
 
-	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	//remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
-	bpb "google.golang.org/genproto/googleapis/bytestream"
+	"github.com/sdclarke/blake-client/pkg/blobuploader"
 	"google.golang.org/grpc"
 )
 
@@ -40,11 +36,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
-	casClient := remoteexecution.NewContentAddressableStorageClient(conn)
+	//casClient := remoteexecution.NewContentAddressableStorageClient(conn)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	blobUploader := blobUploader.NewBlobUploader(conn, 100)
 	instanceName, err := digest.NewInstanceName("blake-client")
 	if err != nil {
 		log.Fatalf("Error creating instance name: %v", err)
@@ -60,88 +55,15 @@ func main() {
 		}
 		hash = d.NewHasher()
 	}
-	file, err := os.Open("/home/scott/buildbarn/bb-storage/randomfile")
+	blobUploader, finaliser := blobuploader.NewBlobUploader(conn, instanceName.String(), 100, hash, blake)
+
+	inputRootDigest, err := blobUploader.UploadDirectory(ctx, inputRoot)
 	if err != nil {
-		log.Fatalf("Failed to open file: %v", err)
+		log.Fatalf("Something went wrong uploading input root: %v", err)
 	}
-	defer file.Close()
-
-	stat, err := file.Stat()
+	err = finaliser(ctx)
 	if err != nil {
-		log.Fatalf("%v", err)
+		log.Fatalf("Something went wrong uploading input root: %v", err)
 	}
-
-	b := make([]byte, stat.Size())
-	_, err = file.Read(b)
-	if err != nil {
-		log.Fatalf("Failed to read file: %v", err)
-	}
-	_, err = file.Seek(0, 0)
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
-
-	if _, err := io.Copy(hash, file); err != nil {
-		log.Fatalf("%v", err)
-	}
-
-	var digest digest.Digest
-	if blake {
-		digest, err = instanceName.NewDigest(fmt.Sprintf("B3Z:%s", hex.EncodeToString(hash.Sum(nil))), stat.Size())
-	} else {
-		digest, err = instanceName.NewDigest(hex.EncodeToString(hash.Sum(nil)), stat.Size())
-	}
-	if err != nil {
-		log.Fatalf("Error creating digest for file: %v", err)
-	}
-	//log.Printf("Digest %v", digest)
-
-	findMissingRequest := &remoteexecution.FindMissingBlobsRequest{
-		InstanceName: instanceName.String(),
-		BlobDigests:  []*remoteexecution.Digest{digest.GetProto()},
-	}
-
-	findMissingResponse, err := casClient.FindMissingBlobs(ctx, findMissingRequest)
-	if err != nil {
-		log.Fatalf("Error with FindMissingBlobs: %v", err)
-	}
-	//log.Printf("Find Missing Response: %v", findMissingResponse)
-
-	if len(findMissingResponse.MissingBlobDigests) != 0 {
-		updateRequest := &remoteexecution.BatchUpdateBlobsRequest{
-			InstanceName: instanceName.String(),
-			Requests: []*remoteexecution.BatchUpdateBlobsRequest_Request{{
-				Digest: digest.GetProto(),
-				Data:   b,
-			}},
-		}
-
-		_, err = casClient.BatchUpdateBlobs(ctx, updateRequest)
-		if err != nil {
-			log.Fatalf("Error with BatchUpdateBlobs: %v", err)
-		}
-	}
-
-	//log.Printf("Response %v", updateResponse)
-
-	//readResponse, err := casClient.BatchReadBlobs(ctx, &remoteexecution.BatchReadBlobsRequest{
-	//InstanceName: "test",
-	//Digests:      []*remoteexecution.Digest{digest.GetProto()},
-	//})
-	//if err != nil {
-	//log.Fatalf("Error with BatchReadBlobs: %v", err)
-	//}
-
-	//newFile, err := os.Create("/home/scott/output.png")
-	//if err != nil {
-	//log.Fatalf("Failed to create output file: %v", err)
-	//}
-
-	//_, err = newFile.Write(readResponse.Responses[0].Data)
-	//if err != nil {
-	//log.Fatalf("Failed to write to output file: %v", err)
-	//}
-	//if manifestDigest, _, ok := digest.ToManifest(int64(8 * 1024)); ok {
-	//log.Printf("Manifest Size: %v", manifestDigest.GetSizeBytes())
-	//}
+	log.Printf("Input root digest: %v", inputRootDigest)
 }

--- a/pkg/blobuploader/BUILD.bazel
+++ b/pkg/blobuploader/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["blob_uploader.go"],
+    importpath = "github.com/sdclarke/blake-client/pkg/blobuploader",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
+        "@go_googleapis//google/bytestream:bytestream_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+    ],
+)

--- a/pkg/blobuploader/blob_uploader.go
+++ b/pkg/blobuploader/blob_uploader.go
@@ -1,9 +1,26 @@
 package blobuploader
 
 import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path"
+	"strings"
+
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/uuid"
+
 	bpb "google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+const maxSize = 65536
 
 type blob struct {
 	digest *remoteexecution.Digest
@@ -12,33 +29,228 @@ type blob struct {
 
 type blobUploader struct {
 	bytestreamClient bpb.ByteStreamClient
-	blobs            []*blob
+	casClient        remoteexecution.ContentAddressableStorageClient
+	blobs            map[string]*blob
+	instanceName     string
 	maxSize          int
+	hash             hash.Hash
+	blake            bool
 }
 
-func NewBlobUploader(conn grpc.ClientConnInterface, maxSize int) (*blobUploader, func(context.Context) error) {
+func NewBlobUploader(conn grpc.ClientConnInterface, instanceName string, maxSize int, hash hash.Hash, blake bool) (*blobUploader, func(context.Context) error) {
 	bu := &blobUploader{
 		bytestreamClient: bpb.NewByteStreamClient(conn),
-		blobs:            []*blob{},
+		casClient:        remoteexecution.NewContentAddressableStorageClient(conn),
+		blobs:            make(map[string]*blob),
+		instanceName:     instanceName,
 		maxSize:          maxSize,
+		hash:             hash,
+		blake:            blake,
 	}
 	return bu, func(ctx context.Context) error {
 		return bu.findMissingAndUpload(ctx)
 	}
 }
 
-func (bu *blobUploader) Add(digest *remoteexecution.Digest, b []byte) error {
-	bu.blobs = append(bu.blobs, &blob{digest, b})
-	if len(bu.blobs) == maxSize {
-		err := bu.findMissingAndUpload()
+func (bu *blobUploader) Add(ctx context.Context, digest *remoteexecution.Digest, b []byte) error {
+	hash := digest.GetHashOther()
+	if hash == "" {
+		hash = fmt.Sprintf("B3Z:%s", hex.EncodeToString(digest.GetHashBlake3Zcc()))
+	}
+	if _, ok := bu.blobs[hash]; ok {
+		return nil
+	}
+	bu.blobs[hash] = &blob{digest: digest, b: b}
+	if len(bu.blobs) == bu.maxSize {
+		err := bu.findMissingAndUpload(ctx)
 		if err != nil {
 			return err
 		}
-		bu.blobs = []*blob{}
+		bu.blobs = make(map[string]*blob)
 	}
 	return nil
 }
 
-func (bu *blobUploader) findMissingAndUpload() error {
+func (bu *blobUploader) findMissingAndUpload(ctx context.Context) error {
+	findMissingRequest := &remoteexecution.FindMissingBlobsRequest{
+		InstanceName: bu.instanceName,
+		BlobDigests:  []*remoteexecution.Digest{},
+	}
+	for _, blob := range bu.blobs {
+		findMissingRequest.BlobDigests = append(findMissingRequest.BlobDigests, blob.digest)
+	}
+	findMissingResponse, err := bu.casClient.FindMissingBlobs(ctx, findMissingRequest)
+	if err != nil {
+		return err
+	}
+	missing := findMissingResponse.GetMissingBlobDigests()
+	for _, digest := range missing {
+		wr, err := bu.bytestreamClient.Write(ctx)
+		if err != nil {
+			return err
+		}
+		uuid := uuid.New()
+
+		size := digest.GetSizeBytes()
+		hash := digest.GetHashOther()
+		if hash == "" {
+			hash = fmt.Sprintf("B3Z:%s", hex.EncodeToString(digest.GetHashBlake3Zcc()))
+		}
+
+		resourceNameEnd := fmt.Sprintf("blobs/%s/%d", hash, size)
+		resourceName := path.Join(bu.instanceName, "uploads", uuid.String(), resourceNameEnd)
+
+		writeOffset := int64(0)
+		blobBytes := bu.blobs[hash].b
+		for {
+			bytes := make([]byte, maxSize)
+			n := copy(bytes, blobBytes)
+			for n > 0 {
+				// Write request for non-terminating chunk of file
+				writeRequest_file := &bpb.WriteRequest{
+					ResourceName: resourceName,
+					WriteOffset:  writeOffset,
+					FinishWrite:  false,
+					Data:         bytes[:n],
+				}
+
+				if err = wr.Send(writeRequest_file); err != nil {
+					return err
+				}
+				resourceName = ""
+				writeOffset += int64(n)
+				blobBytes = blobBytes[n:]
+				n = copy(bytes, blobBytes)
+			}
+			// Write request for terminating chunk of file
+			writeRequest_file := &bpb.WriteRequest{
+				ResourceName: resourceName,
+				WriteOffset:  writeOffset,
+				FinishWrite:  true,
+			}
+			if err = wr.Send(writeRequest_file); err != nil {
+				return err
+			}
+			break
+		}
+		writeResponse, err := wr.CloseAndRecv()
+		if err != nil {
+			return err
+		}
+		if committedSize := writeResponse.GetCommittedSize(); committedSize < size {
+			return status.Errorf(codes.Unknown, "Committed size was %d, expected %d", committedSize, size)
+		}
+	}
 	return nil
+}
+
+func (bu *blobUploader) UploadDirectory(ctx context.Context, directory string) (*remoteexecution.Digest, error) {
+	dir, err := os.Open(directory)
+	if err != nil {
+		return nil, err
+	}
+	fileNames, err := dir.Readdir(0)
+	if err != nil {
+		return nil, err
+	}
+	files := []*remoteexecution.FileNode{}
+	directories := []*remoteexecution.DirectoryNode{}
+	for _, fileName := range fileNames {
+		node, err := bu.createFileNode(ctx, path.Join(directory, fileName.Name()))
+		if err != nil {
+			childDirectoryDigest, err := bu.UploadDirectory(ctx, path.Join(directory, fileName.Name()))
+			if err != nil {
+				return nil, err
+			}
+			directories = append(directories, &remoteexecution.DirectoryNode{
+				Name:   fileName.Name(),
+				Digest: childDirectoryDigest,
+			})
+		} else {
+			files = append(files, node)
+		}
+	}
+	return bu.createDirectory(ctx, files, directories)
+}
+
+func (bu *blobUploader) createDirectory(ctx context.Context, files []*remoteexecution.FileNode, directories []*remoteexecution.DirectoryNode) (*remoteexecution.Digest, error) {
+	directory := &remoteexecution.Directory{
+		Files:       files,
+		Directories: directories,
+	}
+	bytes, err := proto.Marshal(directory)
+	if err != nil {
+		return nil, err
+	}
+	bu.hash.Reset()
+	_, err = bu.hash.Write(bytes)
+	if err != nil {
+		return nil, err
+	}
+	hashBytes := bu.hash.Sum(nil)
+	var inputRootDigest *remoteexecution.Digest
+	if bu.blake {
+		inputRootDigest = &remoteexecution.Digest{
+			HashBlake3Zcc: hashBytes,
+			SizeBytes:     int64(len(bytes)),
+		}
+	} else {
+		inputRootDigest = &remoteexecution.Digest{
+			HashOther: hex.EncodeToString(hashBytes),
+			SizeBytes: int64(len(bytes)),
+		}
+	}
+	bu.Add(ctx, inputRootDigest, bytes)
+	return inputRootDigest, nil
+}
+
+func (bu *blobUploader) createFileNode(ctx context.Context, fileName string) (*remoteexecution.FileNode, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if stat.IsDir() {
+		return nil, status.Error(codes.InvalidArgument, "File is a directory")
+	}
+
+	bu.hash.Reset()
+
+	size, err := io.Copy(bu.hash, file)
+	if err != nil {
+		return nil, err
+	}
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return nil, err
+	}
+	hashBytes := bu.hash.Sum(nil)
+
+	fileNode := &remoteexecution.FileNode{
+		Name:         stat.Name(),
+		IsExecutable: strings.Contains(stat.Mode().Perm().String(), "x"),
+	}
+	if bu.blake {
+		fileNode.Digest = &remoteexecution.Digest{
+			HashBlake3Zcc: hashBytes,
+			SizeBytes:     int64(size),
+		}
+	} else {
+		fileNode.Digest = &remoteexecution.Digest{
+			HashOther: hex.EncodeToString(hashBytes),
+			SizeBytes: int64(size),
+		}
+	}
+	bytes := make([]byte, size)
+	_, err = io.ReadFull(file, bytes)
+	if err != nil {
+		return nil, err
+	}
+	bu.Add(ctx, fileNode.Digest, bytes)
+	return fileNode, nil
 }


### PR DESCRIPTION
This PR will give the client the ability to hash and upload all of the necessary blobs to execute a command on the server.

It separates the code for hashing and uploading out into it's own package called `blobuploader`. This leaves the main file looking much cleaner.

The client does not yet hash or upload any commands or actions, but the inclusion of the `AddProto()` function in the `blobuploader` allows for them to be uploaded once they are created.

In its current state the client takes an input directory from the command line and hashes it, uploads it and returns the digest of the directory.

The `blobuploader` implementation draws inspiration from `BatchedStoreBlobAccess` in bb-remote-execution.

This PR relates to closes #3 and closes #5 