### PR TITLE
Execute

### DIFF
--- a/cmd/blake3zcc_hasher/BUILD.bazel
+++ b/cmd/blake3zcc_hasher/BUILD.bazel
@@ -7,8 +7,12 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/blobuploader:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/digest:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
     ],
 )
 

--- a/cmd/blake3zcc_hasher/main.go
+++ b/cmd/blake3zcc_hasher/main.go
@@ -3,19 +3,39 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"flag"
+	"io"
 	"log"
 
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/sdclarke/blake-client/pkg/blobuploader"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	commands = []*remoteexecution.Command{
+		{
+			Arguments:   []string{"cp", "in", "out"},
+			OutputPaths: []string{"out"},
+		},
+		{
+			Arguments:   []string{"cat", "in", "in", ">", "out"},
+			OutputPaths: []string{"out"},
+		},
+	}
 )
 
 var blake bool
 
-func parseFlags() (string, string) {
+func parseFlags() (string, string, int) {
 	var address string
 	var inputRoot string
+	var commandNumber int
 
 	flag.StringVar(&address, "address", "", "Address of gRPC endpoint for Buildbarn frontend")
 	flag.StringVar(&address, "a", "", "Address of gRPC endpoint for Buildbarn frontend (shorthand)")
@@ -23,13 +43,15 @@ func parseFlags() (string, string) {
 	flag.BoolVar(&blake, "b", true, "True for BLAKE3ZCC, false for SHA256 (shorthand)")
 	flag.StringVar(&inputRoot, "directory", "", "The directory to be the input root of the action")
 	flag.StringVar(&inputRoot, "d", "", "The directory to be the input root of the action (shorthand)")
+	flag.IntVar(&commandNumber, "command", 0, "The number of the command to be run (0-0)")
+	flag.IntVar(&commandNumber, "c", 0, "The number of the command to be run (0-0)")
 	flag.Parse()
 
-	return address, inputRoot
+	return address, inputRoot, commandNumber
 }
 
 func main() {
-	address, inputRoot := parseFlags()
+	address, inputRoot, commandNumber := parseFlags()
 
 	conn, err := grpc.Dial(address, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
@@ -60,9 +82,81 @@ func main() {
 	if err != nil {
 		log.Fatalf("Something went wrong uploading input root: %v", err)
 	}
-	err = finaliser(ctx)
 	if err != nil {
 		log.Fatalf("Something went wrong uploading input root: %v", err)
 	}
-	log.Printf("Input root digest: %v", inputRootDigest)
+
+	command := commands[commandNumber]
+	commandDigest, err := blobUploader.AddProto(ctx, command)
+	if err != nil {
+		log.Fatalf("Error uploading command: %v", err)
+	}
+
+	action := createAction(commandDigest, inputRootDigest)
+	actionDigest, err := blobUploader.AddProto(ctx, action)
+	if err != nil {
+		log.Fatalf("Error uploading action: %v", err)
+	}
+
+	err = finaliser(ctx)
+	if err != nil {
+		log.Fatalf("Error finalising blob uploads %v", err)
+	}
+	log.Printf("Action Digest: %v %v %v %d", actionDigest.GetHashBlake3Zcc(), hex.EncodeToString(actionDigest.GetHashBlake3Zcc()), actionDigest.GetHashOther(), actionDigest.GetSizeBytes())
+
+	executionClient := remoteexecution.NewExecutionClient(conn)
+
+	stream, err := executionClient.Execute(ctx, &remoteexecution.ExecuteRequest{
+		InstanceName: instanceName.String(),
+		ActionDigest: actionDigest,
+	})
+	if err != nil {
+		log.Fatalf("Error calling Execute(): %v", err)
+	}
+
+	executeResponse, err := receiveResults(stream)
+	if err != nil {
+		log.Fatalf("Error receiving results: %v", err)
+	}
+	log.Printf("Execute response: %v", executeResponse)
+
+	actionCacheClient := remoteexecution.NewActionCacheClient(conn)
+
+	actionResult, err := actionCacheClient.GetActionResult(ctx, &remoteexecution.GetActionResultRequest{
+		InstanceName: instanceName.String(),
+		ActionDigest: actionDigest,
+	})
+	if err != nil {
+		log.Fatalf("Error getting action result: %v", err)
+	}
+
+	log.Printf("Action result: %v", actionResult)
+}
+
+func createAction(commandDigest, inputRootDigest *remoteexecution.Digest) *remoteexecution.Action {
+	return &remoteexecution.Action{
+		CommandDigest:   commandDigest,
+		InputRootDigest: inputRootDigest,
+	}
+}
+
+func receiveResults(stream remoteexecution.Execution_ExecuteClient) (*remoteexecution.ExecuteResponse, error) {
+	resp := &remoteexecution.ExecuteResponse{}
+	for {
+		a, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if a.GetDone() {
+			err = ptypes.UnmarshalAny(a.GetResponse(), resp)
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
+		}
+	}
+	return nil, status.Errorf(codes.Internal, "Something is on fire")
 }


### PR DESCRIPTION
This PR builds on #8 and adds the ability to call the execution client and wait for the results from running the commands.

There are some example commands included with this implementation which are used along with the specified input root to create and action and execute it.

Closes #6 and relates to #4 